### PR TITLE
allow running container as non-root

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 *
-!docker/default.conf
+!docker/default.conf.template
 !docker/conf.json.template
 !docker/config_env_subst.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,12 +4,16 @@
 #
 # Copyright (c) 2021-present Kaleidos Ventures SL
 
-FROM nginx:1.19-alpine
+FROM nginxinc/nginx-unprivileged:1.19-alpine
 LABEL maintainer="support@taiga.io"
+ENV LISTEN_PORT=80
+EXPOSE 80
 
-COPY docker/default.conf /etc/nginx/conf.d/default.conf
+COPY docker/default.conf.template /etc/nginx/templates/default.conf.template
 COPY docker/conf.json.template /
 COPY docker/config_env_subst.sh /docker-entrypoint.d/30_config_env_subst.sh
+
+USER 0
 
 RUN set -eux; \
     apk update; \
@@ -35,4 +39,5 @@ RUN set -eux; \
     rm source.zip; \
     # Ready for nginx
     mv /taiga/dist/* /usr/share/nginx/html; \
-    rm -rf /taiga
+    rm -rf /taiga; \
+    chmod -R a+rwX /usr/share/nginx/html

--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen ${LISTEN_PORT} default_server;
 
     client_max_body_size 100M;
     charset utf-8;


### PR DESCRIPTION
It does not run as non-root by default.
But when started with e.g. `--user 101` it will try to run as the given
uid.  Be sure to set `LISTEN_PORT=8080` if you want to do that.

This should not have user-visible changes if not requested.