### PR TITLE
Filter closed epics on epic selection lightbox

### DIFF
--- a/app/coffee/modules/common/lightboxes.coffee
+++ b/app/coffee/modules/common/lightboxes.coffee
@@ -949,7 +949,7 @@ tgResources, $tgResources, $epicsService, tgAnalytics) ->
                     excludeIds = []
                     if (us.epics)
                         excludeIds = us.epics.map((epic) -> epic.id)
-                    filteredData = data.filter((epic) -> excludeIds.indexOf(epic.get('id')) == -1)
+                    filteredData = data.filter((epic) -> excludeIds.indexOf(epic.get('id')) == -1).filter((epic) -> epic.get('is_closed') == false)
                     $scope.projectEpics = filteredData
 
         selectProject = (selectedProjectId) ->


### PR DESCRIPTION
Currently Taiga always shows all epics in the epic selection lightbox. We want to exclude all the done epics.