### PR TITLE
Add clear button to filter lists

### DIFF
--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -712,6 +712,11 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
         @.filtersReloadContent()
         @.generateFilters('null')
 
+    clearFiltersBacklog: () ->
+        @.replaceAllFilters({})        
+        @.filtersReloadContent()
+        @.generateFilters('null')
+
 module.controller("BacklogController", BacklogController)
 
 #############################################################################

--- a/app/coffee/modules/controllerMixins.coffee
+++ b/app/coffee/modules/controllerMixins.coffee
@@ -189,6 +189,11 @@ class UsFiltersMixin
         @.filtersReloadContent()
         @.generateFilters()
 
+    clearFilters: () ->
+        @.replaceAllFilters({})
+        @.filtersReloadContent()
+        @.generateFilters()
+
     addFilter: (newFilter) ->
         @.selectFilter(newFilter.category.dataType, newFilter.filter.id, false, newFilter.mode)
         @.filtersReloadContent()

--- a/app/coffee/modules/issues/list.coffee
+++ b/app/coffee/modules/issues/list.coffee
@@ -143,6 +143,11 @@ class IssuesController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.Fi
         @.loadIssues()
         @.generateFilters()
 
+    clearFilters: () ->
+        @.replaceAllFilters({})
+        @.loadIssues()
+        @.generateFilters()
+
     addFilter: (newFilter) ->
         @.unselectFilter("page")
         @.selectFilter(newFilter.category.dataType, newFilter.filter.id, false, newFilter.mode)

--- a/app/coffee/modules/taskboard/main.coffee
+++ b/app/coffee/modules/taskboard/main.coffee
@@ -154,6 +154,11 @@ class TaskboardController extends mixOf(taiga.Controller, taiga.PageMixin, taiga
         @.loadTasks()
         @.generateFilters()
 
+    clearFilters: () ->
+        @.replaceAllFilters({})
+        @.loadTasks()
+        @.generateFilters()
+
     addFilter: (newFilter) ->
         @.selectFilter(newFilter.category.dataType, newFilter.filter.id, false, newFilter.mode)
         @.loadTasks()

--- a/app/locales/taiga/locale-de.json
+++ b/app/locales/taiga/locale-de.json
@@ -236,6 +236,7 @@
             "TITLE": "Benutzerfilter",
             "TITLE_ACTION_SEARCH": "Suche",
             "ACTION_ADD": "Hinzufügen",
+            "CLEAR": "Zurücksetzen",
             "ACTION_SAVE_CUSTOM_FILTER": "Filter speichern",
             "PLACEHOLDER_FILTER_NAME": "Benennen Sie den Filter und drücken Sie die Eingabetaste",
             "APPLIED_FILTERS_NUM": "Filter wurden angewandt",

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -237,6 +237,7 @@
             "TITLE": "Custom filters",
             "TITLE_ACTION_SEARCH": "Search",
             "ACTION_ADD": "Add",
+            "CLEAR": "Clear",
             "ACTION_SAVE_CUSTOM_FILTER": "save filter",
             "PLACEHOLDER_FILTER_NAME": "Write the filter name and press enter",
             "APPLIED_FILTERS_NUM": "filters applied",

--- a/app/modules/components/filter/filter.controller.coffee
+++ b/app/modules/components/filter/filter.controller.coffee
@@ -49,7 +49,15 @@ class FilterController
         @.lengthZeroError = false
         @.repeatedFilterError = false
 
-    saveCustomFilter: () ->
+    clearCustomFilter: () ->
+        @.customFilterForm = false
+        @.lengthZeroError = false
+        @.repeatedFilterError = false
+        @.activeCustomFilter = null
+
+        @.onClearFilters()
+
+    saveCustomFilter: () -> 
         if @.customFilterName.length > 0 && !@.customFilters.find((filter) => filter.name == @.customFilterName)
             @.lengthZeroError = false
             @.repeatedFilterError = false

--- a/app/modules/components/filter/filter.directive.coffee
+++ b/app/modules/components/filter/filter.directive.coffee
@@ -47,6 +47,7 @@ FilterDirective = () ->
             onAddFilter: "&",
             onSelectCustomFilter: "&",
             onRemoveFilter: "&",
+            onClearFilters: "&",
             onRemoveCustomFilter: "&",
             onSaveCustomFilter: "&",
             customFilters: "<",

--- a/app/modules/components/filter/filter.jade
+++ b/app/modules/components/filter/filter.jade
@@ -58,6 +58,12 @@
                 tg-svg(svg-icon="icon-trash")
 
 .filters-step-cat
+    .clear-filter-wrapper(ng-if="vm.selectedFilters.length")
+        button.clear-filter(
+            ng-click="vm.clearCustomFilter()"
+            translate="COMMON.FILTERS.CLEAR"
+        )
+
     .filters-applied(ng-if="vm.includedFilters.length || vm.excludedFilters.length")
         .filters-included(ng-if="vm.includedFilters.length")
             .filters-title(translate="COMMON.FILTERS.ADVANCED_FILTERS.INCLUDED")

--- a/app/modules/components/filter/filter.scss
+++ b/app/modules/components/filter/filter.scss
@@ -201,6 +201,25 @@ tg-filter {
     }
 }
 
+.clear-filter-wrapper {
+    display: flex;
+    justify-content: flex-end;
+    margin: .5rem 0;
+
+    .clear-filter {
+        @include font-size(small);
+        @include font-type(medium);
+        background: none;
+        color: $color-link-primary;
+        padding: 0;
+        text-transform: lowercase;
+
+        &[disabled] {
+            color: rgba($color-link-primary, .5);
+        }
+    }
+}
+
 .filters-applied {
     border-bottom: 1px solid $color-gray400;
     margin-bottom: .5rem;

--- a/app/partials/backlog/backlog.jade
+++ b/app/partials/backlog/backlog.jade
@@ -136,6 +136,7 @@ div.wrapper(tg-backlog, ng-controller="BacklogController as ctrl",
                             on-select-custom-filter="ctrl.selectCustomFilter(filter)"
                             on-remove-custom-filter="ctrl.removeCustomFilter(filter)"
                             on-remove-filter="ctrl.removeFilterBacklog(filter)"
+                            on-clear-filters="ctrl.clearFiltersBacklog()"
                         )
 
                     section.backlog-table(ng-class="{'hidden': !userstories.length}")

--- a/app/partials/issue/issues.jade
+++ b/app/partials/issue/issues.jade
@@ -92,6 +92,7 @@ div.wrapper.issues.lightbox-generic-form(
                     on-remove-custom-filter="ctrl.removeCustomFilter(filter)"
                     on-remove-filter="ctrl.removeFilter(filter)"
                     on-change-q="ctrl.changeQ(q)"
+                    on-clear-filters="ctrl.clearFilters()"
                 )
 
             section.issues-page(

--- a/app/partials/kanban/kanban.jade
+++ b/app/partials/kanban/kanban.jade
@@ -58,6 +58,7 @@ div.wrapper(
                     on-select-custom-filter="ctrl.selectCustomFilter(filter)"
                     on-remove-custom-filter="ctrl.removeCustomFilter(filter)"
                     on-remove-filter="ctrl.removeFilter(filter)"
+                    on-clear-filters="ctrl.clearFilters()"
                 )
 
             include ../includes/modules/kanban-table

--- a/app/partials/taskboard/taskboard.jade
+++ b/app/partials/taskboard/taskboard.jade
@@ -75,6 +75,7 @@ div.wrapper(
                         on-remove-custom-filter="ctrl.removeCustomFilter(filter)"
                         on-remove-filter="ctrl.removeFilter(filter)"
                         on-change-q="ctrl.changeQ(q)"
+                        on-clear-filters="ctrl.clearFilters()"
                     )
                 include ../includes/modules/taskboard-table
 


### PR DESCRIPTION
Added a clear button to filter lists to reset all selected filters on following pages:

- Kanban
- Backlog
- Issues
- Taskboard

![image](https://github.com/user-attachments/assets/5e34e090-2738-4067-bcb0-66448b00eccc)
