### PR TITLE
Minor accessibility change: Adds "Delete" alt text to Trash can icons.

### DIFF
--- a/app/partials/common/components/delete-button.jade
+++ b/app/partials/common/components/delete-button.jade
@@ -7,5 +7,6 @@
 
 button.btn-icon.button-delete(
     variant="primary"
+    title="{{ 'COMMON.DELETE' | translate }}"
 )
     tg-svg(svg-icon="icon-trash")


### PR DESCRIPTION
The delete icons did not have alt text, an issue for screen readers. Simple one-line fix with translation confirmed in Turkish and Spanish.