### PR TITLE
Issue 255: Toggle section titles from view

### DIFF
--- a/app/coffee/app.coffee
+++ b/app/coffee/app.coffee
@@ -1038,6 +1038,10 @@ init = ($log, $rootscope, $auth, $events, $analytics, $tagManager, $userPilot, $
             navigationBarService.disableHeader()
         else
             navigationBarService.enableHeader()
+            
+    # Whether or not to show the superfluous section titles on page
+    # Default to true if config doesn't exist
+    $rootscope.showSectionTitles = $tgConfig.get("showSectionTitles", true)
 
 # Config for infinite scroll
 angular.module('infinite-scroll').value('THROTTLE_MILLISECONDS', 500)

--- a/app/partials/includes/components/mainTitle.jade
+++ b/app/partials/includes/components/mainTitle.jade
@@ -5,8 +5,9 @@
 //-
 //- Copyright (c) 2021-present Kaleidos INC
 
-header
-    h1(
-        tg-main-title
-        i18n-section-name="{{ sectionName }}"
-    )
+div(ng-if="showSectionTitles")
+    header
+        h1(
+            tg-main-title
+            i18n-section-name="{{ sectionName }}"
+        )

--- a/conf/conf.example.json
+++ b/conf/conf.example.json
@@ -33,5 +33,6 @@
         "ar",
         "fa",
         "he"
-    ]
+    ],
+    "showSectionTitles": true
 }


### PR DESCRIPTION
Issue: https://github.com/taigaio/taiga-front/issues/255

Desired removal of "Kanban" header to maximize space on page for issues, so I added config to remove that as well as other titles if desired. 

When config is set to false, this is what the Kanban section looks like:

<img width="1875" height="558" alt="Screenshot 2026-02-16 191707" src="https://github.com/user-attachments/assets/910ebf23-521e-45f6-bf7c-102882f634cf" />
