### PR TITLE
Issue/back 213/filter archived us epics

### DIFF
--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -152,7 +152,6 @@
             "SLUG": "Slug",
             "COLOR": "Color",
             "IS_CLOSED": "Is closed?",
-            "IS_ARCHIVED": "Archived",
             "STATUS": "Status",
             "TYPE": "Type",
             "SEVERITY": "Severity",

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -152,6 +152,7 @@
             "SLUG": "Slug",
             "COLOR": "Color",
             "IS_CLOSED": "Is closed?",
+            "IS_ARCHIVED": "Archived",
             "STATUS": "Status",
             "TYPE": "Type",
             "SEVERITY": "Severity",

--- a/app/modules/epics/dashboard/epic-row/epic-row.jade
+++ b/app/modules/epics/dashboard/epic-row/epic-row.jade
@@ -6,9 +6,9 @@
 //- Copyright (c) 2021-present Kaleidos INC
 
 .epic-row.e2e-epic-row(
-    ng-class="{'is-blocked':  vm.epic.get('is_blocked'), 'is-closed': vm.epic.get('is_closed'), 'unfold': vm.displayUserStories, 'not-empty': vm.epic.getIn(['user_stories_counts', 'opened']) || vm.epic.getIn(['user_stories_counts', 'closed'])}"
+    ng-class="{'is-blocked':  vm.epic.get('is_blocked'), 'is-closed': vm.epic.get('is_closed'), 'is-archived': vm.epic.get('is_archived'), 'unfold': vm.displayUserStories, 'not-empty': vm.epic.getIn(['user_stories_counts', 'opened']) || vm.epic.getIn(['user_stories_counts', 'closed'])}"
     ng-click="vm.toggleUserStoryList()"
-    ng-hide="!vm.options.closed && vm.epic.get('is_closed')"
+    ng-hide="!vm.options.closed && vm.epic.get('is_closed')  || (!vm.options.archived && vm.epic.get('is_archived'))"
 )
     tg-svg.icon-drag(
         svg-icon="icon-draggable"

--- a/app/modules/epics/dashboard/epics-table/epics-table.jade
+++ b/app/modules/epics/dashboard/epics-table/epics-table.jade
@@ -96,6 +96,18 @@ mixin epicSwitch(name, model)
                         for="switch-closed_us"
                     )
                     +epicSwitch('switch-closed_us', 'vm.options.closed_us')
+                .fieldset
+                    label.epics-table-options-vote(
+                        translate="EPICS.TABLE.ARCHIVED_EPICS"
+                        for="switch-archived"
+                    )
+                    +epicSwitch('switch-archived', 'vm.options.archived')
+                .fieldset
+                    label.epics-table-options-vote(
+                        translate="EPICS.TABLE.ARCHIVED_US"
+                        for="switch-archived_us"
+                    )
+                    +epicSwitch('switch-archived_us', 'vm.options.archived_us')
 
     .epics-table-body(
         tg-epics-sortable="vm.reorderEpic(epic, newIndex)"

--- a/app/modules/epics/dashboard/story-row/story-row.jade
+++ b/app/modules/epics/dashboard/story-row/story-row.jade
@@ -6,8 +6,8 @@
 //- Copyright (c) 2021-present Kaleidos INC
 
 .story-row(
-    ng-class="{'is-blocked': vm.story.get('is_blocked'), 'is-closed': vm.story.get('is_closed')}"
-    ng-hide="!vm.options.closed_us && vm.story.get('is_closed')"
+    ng-class="{'is-blocked': vm.story.get('is_blocked'), 'is-closed': vm.story.get('is_closed'), 'is-archived': vm.story.get('is_archived')}"
+    ng-hide="(!vm.options.closed_us && vm.story.get('is_closed')) || (!vm.options.archived_us && vm.story.get('is_archived'))"
 )
     .name(ng-if="vm.options.name")
         .name-container

--- a/app/partials/includes/modules/admin/project-status.jade
+++ b/app/partials/includes/modules/admin/project-status.jade
@@ -20,7 +20,8 @@ section.admin-status-table
                 div.color-column(translate="COMMON.FIELDS.COLOR")
                 div.status-name(translate="COMMON.FIELDS.NAME")
                 div.status-slug(translate="COMMON.FIELDS.SLUG")
-                div.is-closed-column(translate="COMMON.FIELDS.IS_CLOSED")
+                div.is-closed-column(translate="ADMIN.US_STATUS.IS_CLOSED_COLUMN")
+                div.is-archived-column(translate="")
                 div.options-column
         div.sortable
             div(ng-repeat="value in values", tg-bind-scope)
@@ -41,6 +42,8 @@ section.admin-status-table
                                 ng-show="value.is_closed"
                                 svg-icon="icon-check"
                             )
+
+                        div.is-archived-column
 
                         div.options-column
                             a.edit-value(href="")
@@ -78,6 +81,8 @@ section.admin-status-table
                                 data-required="true"
                                 ng-options="e.id as e.name | translate for e in [{'id':true, 'name':'COMMON.YES'},{'id':false, 'name': 'COMMON.NO'}]")
 
+                        div.is-archived-column
+
                         div.options-column
                             a.save.e2e-save(href="", title="{{'COMMON.SAVE' | translate}}")
                                 tg-svg(svg-icon="icon-check-empty")
@@ -110,6 +115,8 @@ section.admin-status-table
                         data-required="true"
                         ng-options="e.id as e.name | translate for e in [{'id':true, 'name': 'COMMON.YES'},{'id':false, 'name': 'COMMON.NO'}]"
                     )
+
+                div.is-archived-column
 
                 div.options-column
                     a.add-new.e2e-save(href="", title="{{'COMMON.ADD' | translate}}")

--- a/app/partials/includes/modules/admin/project-status.jade
+++ b/app/partials/includes/modules/admin/project-status.jade
@@ -21,7 +21,7 @@ section.admin-status-table
                 div.status-name(translate="COMMON.FIELDS.NAME")
                 div.status-slug(translate="COMMON.FIELDS.SLUG")
                 div.is-closed-column(translate="ADMIN.US_STATUS.IS_CLOSED_COLUMN")
-                div.is-archived-column(translate="")
+                div.is-archived-column(translate="COMMON.FIELDS.IS_ARCHIVED")
                 div.options-column
         div.sortable
             div(ng-repeat="value in values", tg-bind-scope)
@@ -44,6 +44,10 @@ section.admin-status-table
                             )
 
                         div.is-archived-column
+                            tg-svg(
+                                ng-show="value.is_archived"
+                                svg-icon="icon-check"
+                            )
 
                         div.options-column
                             a.edit-value(href="")
@@ -82,6 +86,11 @@ section.admin-status-table
                                 ng-options="e.id as e.name | translate for e in [{'id':true, 'name':'COMMON.YES'},{'id':false, 'name': 'COMMON.NO'}]")
 
                         div.is-archived-column
+                            select(
+                                name="is_archived"
+                                ng-model="value.is_archived"
+                                data-required="true"
+                                ng-options="e.id as e.name | translate for e in [{'id':true, 'name':'COMMON.YES'},{'id':false, 'name': 'COMMON.NO'}]")
 
                         div.options-column
                             a.save.e2e-save(href="", title="{{'COMMON.SAVE' | translate}}")
@@ -117,6 +126,12 @@ section.admin-status-table
                     )
 
                 div.is-archived-column
+                    select(
+                        name="is_archived"
+                        ng-model="newValue.is_archived"
+                        data-required="true"
+                        ng-options="e.id as e.name | translate for e in [{'id':true, 'name': 'COMMON.YES'},{'id':false, 'name': 'COMMON.NO'}]"
+                    )
 
                 div.options-column
                     a.add-new.e2e-save(href="", title="{{'COMMON.ADD' | translate}}")

--- a/app/partials/includes/modules/admin/project-status.jade
+++ b/app/partials/includes/modules/admin/project-status.jade
@@ -20,8 +20,8 @@ section.admin-status-table
                 div.color-column(translate="COMMON.FIELDS.COLOR")
                 div.status-name(translate="COMMON.FIELDS.NAME")
                 div.status-slug(translate="COMMON.FIELDS.SLUG")
-                div.is-closed-column(translate="ADMIN.US_STATUS.IS_CLOSED_COLUMN")
-                div.is-archived-column(translate="COMMON.FIELDS.IS_ARCHIVED")
+                div.is-closed-column(translate="COMMON.FIELDS.IS_CLOSED")
+                div.is-archived-column(translate="ADMIN.US_STATUS.IS_ARCHIVED_COLUMN")
                 div.options-column
         div.sortable
             div(ng-repeat="value in values", tg-bind-scope)


### PR DESCRIPTION
Uses a new "archived" field of Epics to filter on the Epics page. Requires the pull request for issue 213 of taiga-back, https://github.com/taigaio/taiga-back/pull/230. Builds on #262 . Tested manually with epics and user stories with orthogonal closed and archived statuses. (There is a prior-existing bug where closed User Stories are not hidden when the radio is toggled. This is not addressed by this PR.)