### PR TITLE
Issue 193: Updated to allow editing of sprint name on task board page

### DIFF
--- a/app/coffee/modules/taskboard/main.coffee
+++ b/app/coffee/modules/taskboard/main.coffee
@@ -79,6 +79,7 @@ class TaskboardController extends mixOf(taiga.Controller, taiga.PageMixin, taiga
         @scope.userstories = []
         @.openFilter = false
         @.filterQ = ''
+        @editingSprintName = false
         @.backToBacklogUrl = @navUrls.resolve('project-backlog', {
             project: @projectService.project.get('slug'),
             ref: @params.ref
@@ -771,6 +772,20 @@ class TaskboardController extends mixOf(taiga.Controller, taiga.PageMixin, taiga
             return @location.search().order_by
         else
             return "created_date"
+
+    editSprint: () ->
+        @editedSprintName = @scope.sprint.name
+        @editingSprintName = true
+
+
+    saveSprintName: ->
+        sprint = @scope.sprint
+        return unless sprint?
+        newName = @editedSprintName
+        @scope.sprint.name = newName
+        @repo.save(sprint).then =>
+            @scope.sprint.name = newName
+            @editingSprintName = false
 
 module.controller("TaskboardController", TaskboardController)
 

--- a/app/partials/taskboard/taskboard.jade
+++ b/app/partials/taskboard/taskboard.jade
@@ -1,4 +1,3 @@
-
 //- This source code is licensed under the terms of the
 //- GNU Affero General Public License found in the LICENSE file in
 //- the root directory of this source tree.
@@ -16,8 +15,37 @@ div.wrapper(
     section.main.taskboard
         .taskboard-header
             h1
-                span.green(tg-bo-bind="sprint.name")
-                .date(tg-date-range="sprint.estimated_start,sprint.estimated_finish")
+                span.green(ng-if="!ctrl.editingSprintName") {{ sprint.name }}
+                .date(ng-if="!ctrl.editingSprintName" tg-date-range="sprint.estimated_start,sprint.estimated_finish")
+                
+                // Inline edit mode
+                input.sprint-edit-input(
+                    ng-if="ctrl.editingSprintName"
+                    ng-model="ctrl.editedSprintName"
+                    ng-blur="ctrl.saveSprintName()"
+                    ng-keyup="$event.keyCode == 13 && ctrl.saveSprintName()"
+                    ng-init="focusMe = true"
+                    tg-autofocus="focusMe"
+                )
+
+                // Edit button (pencil)
+                a.edit-sprint.taskboard-btn(
+                    ng-if="!ctrl.editingSprintName"
+                    ng-click="ctrl.editSprint()"
+                    href=""
+                    title="{{'BACKLOG.EDIT_SPRINT' | translate}}"
+                )
+                    tg-svg(svg-icon="icon-edit")
+
+                // Save button (checkmark)
+                a.save-sprint.taskboard-btn(
+                    ng-if="ctrl.editingSprintName"
+                    ng-click="ctrl.saveSprintName()"
+                    href=""
+                    title="{{'COMMON.SAVE' | translate}}"
+                )
+                    tg-svg(svg-icon="icon-save")
+                
 
         .taskboard-inner
             include ../includes/components/sprint-summary
@@ -68,7 +96,7 @@ div.wrapper(
                         filters="ctrl.filters"
                         custom-filters="ctrl.customFilters"
                         selected-filters="ctrl.selectedFilters"
-                        customFilters="ctl.customFilters"
+                        customFilters="ctrl.customFilters"
                         on-save-custom-filter="ctrl.saveCustomFilter(name)"
                         on-add-filter="ctrl.addFilter(filter)"
                         on-select-custom-filter="ctrl.selectCustomFilter(filter)"

--- a/app/styles/layout/taskboard.scss
+++ b/app/styles/layout/taskboard.scss
@@ -138,3 +138,28 @@
         width: 185px;
     }
 }
+
+.save-sprint.taskboard-btn,
+.edit-sprint.taskboard-btn {
+    align-items: center;
+    display: inline-flex;
+    margin-left: 8px;
+    opacity: .7;
+    transition: opacity .15s ease;
+}
+
+.edit-sprint.taskboard-btn:hover {
+    opacity: 1;
+}
+
+.sprint-edit-input {
+    border: 1px solid rgb(204, 204, 204); // replaces #ccc
+    border-radius: 3px;
+    font-size: 1.4rem;
+    padding: 2px 4px;
+    width: auto;
+}
+
+
+
+


### PR DESCRIPTION
Updated to where we can now edit the sprint name, added minor styling for the save and edit button:

<img width="1291" height="470" alt="Screenshot 2026-03-08 120811" src="https://github.com/user-attachments/assets/556cb602-09cb-4954-86a5-714df561b02d" />

<img width="883" height="437" alt="Screenshot 2026-03-08 120722" src="https://github.com/user-attachments/assets/3d7ec3b4-dc16-41e5-b658-59fb3372915f" />

